### PR TITLE
Add skip comments after header

### DIFF
--- a/maf2dist.cxx
+++ b/maf2dist.cxx
@@ -141,6 +141,14 @@ void skip_blank_lines(FILE *file)
 	ungetc(c, file);
 }
 
+void skip_possible_comment(FILE *file)
+{
+	int c;
+	if ((c = fgetc(file)) == '#')
+		forward_to_next_line(file);
+	
+}
+
 class line
 {
 	static auto strip_name(const char *c_name)
@@ -363,8 +371,7 @@ void convert(const std::string &file_name)
 
 	forward_to_next_line(file);
 
-	fscanf(file, "#");
-	forward_to_next_line(file);
+	skip_possible_comment(file);
 
 	skip_blank_lines(file);
 

--- a/maf2dist.cxx
+++ b/maf2dist.cxx
@@ -362,6 +362,10 @@ void convert(const std::string &file_name)
 	fscanf(file, "##maf");
 
 	forward_to_next_line(file);
+
+	fscanf(file, "#");
+	forward_to_next_line(file);
+
 	skip_blank_lines(file);
 
 	while (fgetc(file) == 'a') {


### PR DESCRIPTION
Hey,

thank you for this program!

I added a function to skip possible comments after the header line that start with '#'.
They are allowed I guess, according to https://genome.ucsc.edu/FAQ/FAQformat.html#format5. 

Cheers